### PR TITLE
Use FIREURLD_BROWSER environment variable for daemon

### DIFF
--- a/src/bin/fireurl/main.rs
+++ b/src/bin/fireurl/main.rs
@@ -21,7 +21,7 @@ fn main() -> ExitCode {
 
     if var_os("container").is_none() {
         /* Not running in a container (firejail, flatpak, podman, ...), open url directly */
-        fireurl::open(&url);
+        fireurl::open(&url, "FIREURL_BROWSER");
     } else {
         /* Running in a container, ask fireurld to open the url */
         let socket = UnixDatagram::unbound().expect("Failed to create unbound UNIX socket");

--- a/src/bin/fireurld/main.rs
+++ b/src/bin/fireurld/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), ExitCode> {
             }
         };
         if fireurl::is_uri_trustworthy(url) {
-            fireurl::open(&url);
+            fireurl::open(&url, "FIREURLD_BROWSER");
         } else {
             eprintln!("INFO: Not opening uri that failed check.");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub fn is_uri_trustworthy(uri: &str) -> bool {
             .any(|b| b == b':')
 }
 
-pub fn open<S: AsRef<OsStr>>(url: &S) {
-    let browser = match var_os("FIREURL_BROWSER") {
+pub fn open<S: AsRef<OsStr>>(url: &S, env_name: &str) {
+    let browser = match var_os(env_name) {
         Some(browser) => Cow::Owned(browser),
         None => Cow::Borrowed(OsStr::new("firefox")),
     };
@@ -50,5 +50,5 @@ pub fn open<S: AsRef<OsStr>>(url: &S) {
     Command::new(browser)
         .arg(url.as_ref())
         .spawn()
-        .expect("Failed to spawn firefox");
+        .expect("Failed to spawn browser");
 }

--- a/systemd/fireurld.service
+++ b/systemd/fireurld.service
@@ -3,7 +3,7 @@ Description=fireurl deamon
 
 [Service]
 ExecStart=/opt/fireurl/bin/fireurld
-Environment=FIREURL_BROWSER=firefox
+Environment=FIREURLD_BROWSER=firefox
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This PR introduces a different environment variable to be used by `fireurld` daemon: `FIREURLD_BROWSER`.

Separate environment variables for client and daemon allow chaining execution from daemon to client using `xdg-open`.

Example scheme where `FIREURLD_BROWSER` differs from `FIREURL_BROWSER`. Assuming a user clicks a link within a containerized application (not browser). By default an application calls `xdg-open`, which handles the request:
```
xdg-open (container)
v
fireurl (container)
v
fireurld (host)
v
xdg-open (host)
v
fireurl (host)
v
firefox
```

In the scheme above:
* `FIREURL_BROWSER`: default (`firefox`)
* `FIREURLD_BROWSER`: `xdg-open`

Chaining from one container into another, as well, as from host to a container is also possible. The dispatch is based on the `MimeType` property of XDG `desktop` files.

Containerized applications accepting external requests may specify `Exec` property as a script starting the new application instance via `firejail` or using existing instance via `nsenter` commands.